### PR TITLE
Make child method public

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,14 @@ let ext = ExtendedPrivKey::derive(seed, "m/44'/60'/0'/0/0").unwrap();
 
 // Byte array of the secp256k1 secret key that can be used with Bitcoin or Ethereum.
 assert_eq!(&ext.secret(), b"\x98\x84\xbf\x56\x24\xfa\xdd\x7f\xb2\x80\x4c\xfb\x0c\xb6\xf7\x1f\x28\x9e\x21\x1f\xcf\x0d\xe8\x36\xa3\x84\x17\x57\xda\xd9\x70\xd0");
+
+// Deriving child keys from base one is also possible
+use tiny_hderive::bip44::ChildNumber;
+use std::str::FromStr;
+
+let base_ext = ExtendedPrivKey::derive(seed, "m/44'/60'/0'/0").unwrap();
+// child_ext is a key which is derived from this path: m/44'/60'/0'/0/0
+let child_ext = base_ext.child(ChildNumber::from_str("0").unwrap()).unwrap();
+
+assert_eq!(ext, child_ext);
 ```

--- a/src/bip32.rs
+++ b/src/bip32.rs
@@ -71,7 +71,7 @@ impl ExtendedPrivKey {
         self.secret_key.serialize()
     }
 
-    fn child(&self, child: ChildNumber) -> Result<ExtendedPrivKey, Error> {
+    pub fn child(&self, child: ChildNumber) -> Result<ExtendedPrivKey, Error> {
         let mut hmac: Hmac<Sha512> = Hmac::new_varkey(&self.chain_code)
             .map_err(|_| Error::InvalidChildNumber)?;
 

--- a/src/bip32.rs
+++ b/src/bip32.rs
@@ -138,5 +138,15 @@ mod tests {
         let public_key = secret_key.public();
 
         assert_eq!(expected_address, public_key.address(), "Address is invalid");
+
+        // Test child method
+        let account = ExtendedPrivKey::derive(seed.as_bytes(), "m/44'/60'/0'/0").unwrap().child(ChildNumber::from_str("0").unwrap()).unwrap();
+
+        assert_eq!(expected_secret_key, &account.secret(), "Secret key is invalid");
+
+        let secret_key = SecretKey::from_raw(&account.secret()).unwrap();
+        let public_key = secret_key.public();
+
+        assert_eq!(expected_address, public_key.address(), "Address is invalid");
     }
 }


### PR DESCRIPTION
Hi, I found this tiny library very useful!

However for some use cases when one needs to generate multiple private key for the same base path (only the last index changes) from performance reasons it's better to use `child` method on base private key than calling `derive`.

So here is my tiny PR which makes the `child` method available to use from outside.