### PR TITLE
Create ChildNumber from u32

### DIFF
--- a/src/bip44.rs
+++ b/src/bip44.rs
@@ -20,6 +20,14 @@ impl ChildNumber {
 	pub fn to_bytes(&self) -> [u8; 4] {
 		self.0.to_be_bytes()
 	}
+
+	pub fn hardened_from_u32(index: u32) -> Self {
+		ChildNumber(index | HARDENED_BIT)
+	}
+
+	pub fn non_hardened_from_u32(index: u32) -> Self {
+		ChildNumber(index)
+	}
 }
 
 impl FromStr for ChildNumber {


### PR DESCRIPTION
Not sure if you're accepting pull requests, but this would be super convenient as I'm currently taking u32s, converting them into a string and using that string to get a `ChildNumber`. Another option would be to do this: `ChildNumber(pub u32)`, but that leaves any bitmasking to the user which is less convenient.

Let me know if there's anything I else I can do, or feel free to tell me why you wouldn't want this functionality.